### PR TITLE
Link to working implementation of ERC-721

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -421,7 +421,7 @@
       <!-- /.section-header-text -->
       <div id="get-started-columns" class="columns">
         <div class="column">
-          <a href="https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/token/ERC721/ERC721BasicToken.sol">
+          <a href="https://github.com/0xcert/ethereum-erc721/tree/master/contracts/tokens">
             <h4 class="get-started-links">Copy ERC-721 Template</h4>
           </a>
         </div>


### PR DESCRIPTION
Please link to the 0xcert implementation of ERC-721. This is the preferred implementation and it is linked in the ERC-721.md standard text.

The current link points to OpenZeppelin. That implementation is broken. This is well documented in the OpenZeppelin repository issues. Please do not link to OZ. Additionally, that company does not fund a bug bounty. This is a philosophical problem which provides financial motivation for them to not fix the bug. 0xcert does have a cash bounty for their implementation, it is categorically better.

Disclosure: I have reviewed the 0xcert implementation and I am advising that company.