### PR TITLE
index.html: fix broken axiom zen link

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -250,7 +250,7 @@
       <div class="section-header-text">
         <p class="section-text">ERC-721 started as a EIP draft written by
           <a href="https://github.com/dete">@dete</a> and first came to life in the CryptoKitties project by
-          <a href="https://wwww.axiomzen.com">Axiom Zen</a>
+          <a href="https://www.axiomzen.co/">Axiom Zen</a>
           <br/>
           <br/> ERC-721 has since moved out of beta and into a community formalized v1 spec, supported and endorsed by a large
           number of projects from across the crypto ecosystem. This EIP wouldn't be possible without time and dedication


### PR DESCRIPTION
this link couldn't have been more wrong: 4 Ws instead of 3 and .com instead of .co :)