### PR TITLE
Fixed link to ERC721 openzeppelin repo

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -472,7 +472,7 @@
       <!-- /.section-header-text -->
       <div id="get-started-columns" class="columns">
         <div class="column">
-          <a href="https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/token/ERC721/ERC721BasicToken.sol">
+          <a href="https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC721/ERC721.sol">
             <h4 class="get-started-links">Copy ERC-721 Template</h4>
           </a>
         </div>


### PR DESCRIPTION
The original link was broken when zeppelin renamed their repo and contract template.