### PR TITLE
Replace RareBits with due to project closure

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -516,8 +516,8 @@
           </a>
         </div>
         <div class="column">
-          <a href="https://www.rarebits.io">
-            <h4 class="get-started-links">RareBits</h4>
+          <a href="https://rarible.com">
+            <h4 class="get-started-links">Rarible</h4>
           </a>
         </div>
         <div class="column">


### PR DESCRIPTION
This is a proposal to edit `Trade ERC-721 Tokens` block of the website.
The case here is that Rarebits is officially out of business. 
My proposal here is to replace it with Rarible marketplace which is pretty active in the space (14th by activity on https://etherscan.io/tokens-nft)